### PR TITLE
Updates for mirBase 22.1

### DIFF
--- a/src/msk/mirbase/MatureIdMapper.java
+++ b/src/msk/mirbase/MatureIdMapper.java
@@ -29,12 +29,12 @@ import org.bridgedb.rdb.construct.GdbConstructImpl3;
 public class MatureIdMapper {
 	
 	// change bridgeName if needed = output file
-	private static String bridgeName = "mirBase-mature-v21.bridge";
+	private static String bridgeName = "mirBase-mature-v22.1.bridge";
 	private static String dbName = "mirBase mature";
-	private static String dbVersion = "v21";
+	private static String dbVersion = "v22.1";
 	private static String type = "mature microRNAs";
 	
-	private static String mirbaseUrl = "ftp://mirbase.org/pub/mirbase/CURRENT/aliases.txt.zip";
+	private static String mirbaseUrl = "https://www.mirbase.org/ftp/CURRENT/aliases.txt.zip";
 	
 	public static void main(String[] args) {
 		try {


### PR DESCRIPTION
QC for Derby file:

```
INFO: old database is mirBase mature v21 (build: 20160808)
INFO: new database is mirBase mature v22.1 (build: 20220729)
INFO: Number of ids in Mbm (miRBase mature sequence): 107698 (26780 added, 0 removed -> overall changed +33.1%)
INFO: new size is 36 Mb (changed +31.1%)
INFO: total number of identifiers is 107698
INFO: total number of mappings is 107844
```

I have a Derby file for a new Release, but cannot attach that here, it seems.